### PR TITLE
show editor title icon only when needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
         {
           "command": "kaleidoscope.diffFile",
           "group": "navigation",
-          "when": "editorIsOpen && !textCompareEditorActive"
+          "when": "editorIsOpen && !textCompareEditorActive && resourceScheme == file"
         },
         {
           "command": "kaleidoscope.textCompareEditor",


### PR DESCRIPTION
this avoids showing the icon in wrong places like `untitled files, settings page, extension page, etc...`